### PR TITLE
Add authors and contributors list to REAME.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Features
 Community
 ---------
 
-About us: See :doc:`Authors </authors>`
+About us: `Authors <https://mlbench.readthedocs.io/en/latest/authors.html/>`_:
 
 Mailing list: https://groups.google.com/d/forum/mlbench
 


### PR DESCRIPTION
Hi there, just a small change in README.

I'm studying the repository on MLBench, and while taking a look at this one I noticed that the link to the authors' list was null. I then added a link to the website section. 

I noticed that there is not an authors' list in every repository, so I would suggest to link to the list on the website (and keep it updated) instead of adding a list to all repositories and changing it every time the original list changes.