### PR TITLE
Pytorch v1.4.0

### DIFF
--- a/pytorch/base/Dockerfile
+++ b/pytorch/base/Dockerfile
@@ -1,17 +1,19 @@
-#FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 as mlbench-worker-base
-FROM nvidia/cuda:9.0-devel-ubuntu16.04 as mlbench-worker-base
+# Cuda 10.0 Base image
+FROM nvidia/cuda:10.1-devel-ubuntu16.04 as mlbench-worker-base
 LABEL maintainer "NVIDIA CORPORATION <cudatools@nvidia.com>"
 
-ENV CUDNN_VERSION 7.3.0.29
+# CuDNN version that works with K80 and T4
+ENV CUDNN_VERSION 7.5.0.56
+ENV CUDA_VERSION 10.1
 LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
 
+# -------------------- CUDA DEPENDENCIES --------------------
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-            libcudnn7=$CUDNN_VERSION-1+cuda9.0 \
-            libcudnn7-dev=$CUDNN_VERSION-1+cuda9.0 && \
+            libcudnn7=$CUDNN_VERSION-1+cuda$CUDA_VERSION \
+            libcudnn7-dev=$CUDNN_VERSION-1+cuda$CUDA_VERSION && \
     apt-mark hold libcudnn7 && \
     rm -rf /var/lib/apt/lists/*
-
-# TODO: reduce size and complexity of image.
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
@@ -39,13 +41,6 @@ RUN mkdir -p /.sshd/user_keys/$SSH_USER && \
   chown -R $SSH_USER:$SSH_USER /.sshd/user_keys/$SSH_USER && chmod 700 /.sshd/user_keys/$SSH_USER
 VOLUME /ssh-key/$SSH_USER
 
-# -----–––---------------------- Cuda Dependency --------------------
-RUN echo "deb http://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64 /" > /etc/apt/sources.list.d/nvidia-ml.list
-RUN apt-get update && apt-get install -y --no-install-recommends --allow-downgrades \
-        --allow-change-held-packages \
-         libnccl2=2.0.5-3+cuda9.0 \
-         libnccl-dev=2.0.5-3+cuda9.0 &&\
-     rm -rf /var/lib/apt/lists/*
 
 # -------------------- Conda environment --------------------
 RUN curl -o ~/miniconda.sh -LO  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh  && \
@@ -56,20 +51,20 @@ ENV LD_LIBRARY_PATH /conda/lib:$LD_LIBRARY_PATH
 # TODO: Source code in Channel Anaconda can be outdated, switch to conda-forge if posible.
 RUN conda install -y -c anaconda numpy pyyaml scipy mkl setuptools cmake cffi mkl-include typing \
     && conda install -y -c mingfeima mkldnn \
-    && conda install -y -c soumith magma-cuda90 \
+    && conda install -y -c soumith magma-cuda101 \
     && conda install -y -c conda-forge python-lmdb opencv numpy \
     && conda clean --all -y
 
 # -------------------- Open MPI --------------------
 RUN mkdir /.openmpi/
 RUN apt-get update && apt-get install -y --no-install-recommends wget \
-    && wget https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-3.0.0.tar.gz\
-    && gunzip -c openmpi-3.0.0.tar.gz | tar xf - \
-    && cd openmpi-3.0.0 \
+    && wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.3.tar.gz\
+    && gunzip -c openmpi-4.0.3.tar.gz | tar xf - \
+    && cd openmpi-4.0.3 \
     && ./configure --prefix=/.openmpi/ --with-cuda\
     && make all install \
-    && rm /openmpi-3.0.0.tar.gz \
-    && rm -rf /openmpi-3.0.0 \
+    && rm /openmpi-4.0.3.tar.gz \
+    && rm -rf /openmpi-4.0.3 \
     && apt-get remove -y wget
 
 ENV PATH /.openmpi/bin:$PATH
@@ -94,21 +89,18 @@ RUN echo export 'LD_LIBRARY_PATH=$HOME/.openmpi/lib:$LD_LIBRARY_PATH' >> ~/.bash
 # -------------------- PyTorch --------------------
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
-# Install basic dependencies
-# RUN git clone --recursive https://github.com/pytorch/pytorch && cd pytorch && python setup.py install
+# Build pytorch from source
 RUN git clone --recursive https://github.com/pytorch/pytorch && \
     cd pytorch && \
-    git checkout tags/v1.0.0 && \
-    git submodule update --init && \
+    git checkout v1.4.1 && \
+    git submodule update --init --recursive && \
     TORCH_CUDA_ARCH_LIST="3.5 3.7 5.2 6.0 6.1 7.0+PTX" TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
     CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" \
     pip install -v . && \
     rm -rf /pytorch
 
 
-
-RUN git clone https://github.com/pytorch/vision.git && cd vision && pip install -v .
-
+RUN git clone https://github.com/pytorch/vision.git && cd vision && git checkout tags/v0.5.0 &&  pip install -v .
 # RUN pip install -U git+https://github.com/ppwwyyxx/tensorpack.git
 
 # RUN conda install -y -c anaconda msgpack

--- a/pytorch/imagerecognition/cifar10-resnet20-all-reduce-scaling/Dockerfile
+++ b/pytorch/imagerecognition/cifar10-resnet20-all-reduce-scaling/Dockerfile
@@ -1,4 +1,4 @@
-FROM mlbench/mlbench-pytorch-base:pytorch-v1.0.0
+FROM mlbench/mlbench-pytorch-base:pytorch-v1.4.0
 
 # -------------------- Debug --------------------
 # RUN apt-get update && apt-get install -y vim net-tools

--- a/pytorch/imagerecognition/cifar10-resnet20-all-reduce-scaling/main.py
+++ b/pytorch/imagerecognition/cifar10-resnet20-all-reduce-scaling/main.py
@@ -64,7 +64,7 @@ def train_loop(
         momentum=0.9,
         weight_decay=1e-4,
         nesterov=False,
-        use_cuda=dist.get_backend() == dist.Backend.NCCL,
+        use_cuda=use_cuda,
         by_layer=by_layer,
     )
 

--- a/pytorch/imagerecognition/cifar10-resnet20-all-reduce-scaling/requirements.txt
+++ b/pytorch/imagerecognition/cifar10-resnet20-all-reduce-scaling/requirements.txt
@@ -1,1 +1,1 @@
-mlbench-core==2.3.2.dev1
+mlbench-core==2.4.0

--- a/pytorch/imagerecognition/cifar10-resnet20-all-reduce/Dockerfile
+++ b/pytorch/imagerecognition/cifar10-resnet20-all-reduce/Dockerfile
@@ -1,4 +1,4 @@
-FROM  mlbench/mlbench-pytorch-base:pytorch-v1.0.0
+FROM  mlbench/mlbench-pytorch-base:pytorch-v1.4.0
 
 # -------------------- Debug --------------------
 RUN apt-get update && apt-get install -y vim net-tools

--- a/pytorch/imagerecognition/cifar10-resnet20-all-reduce/main.py
+++ b/pytorch/imagerecognition/cifar10-resnet20-all-reduce/main.py
@@ -64,7 +64,7 @@ def train_loop(
         momentum=0.9,
         weight_decay=1e-4,
         nesterov=False,
-        use_cuda=dist.get_backend() == dist.Backend.NCCL,
+        use_cuda=use_cuda,
         by_layer=by_layer,
     )
 

--- a/pytorch/imagerecognition/cifar10-resnet20-all-reduce/requirements.txt
+++ b/pytorch/imagerecognition/cifar10-resnet20-all-reduce/requirements.txt
@@ -1,1 +1,1 @@
-mlbench-core==2.3.2.dev1
+mlbench-core==2.4.0

--- a/pytorch/linearmodels/epsilon-logistic-regression-all-reduce/Dockerfile
+++ b/pytorch/linearmodels/epsilon-logistic-regression-all-reduce/Dockerfile
@@ -1,4 +1,4 @@
-FROM mlbench/mlbench-pytorch-base:pytorch-v1.0.0
+FROM mlbench/mlbench-pytorch-base:pytorch-v1.4.0
 # -------------------- Debug --------------------
 # RUN apt-get update && apt-get install -y vim net-tools
 

--- a/pytorch/linearmodels/epsilon-logistic-regression-all-reduce/main.py
+++ b/pytorch/linearmodels/epsilon-logistic-regression-all-reduce/main.py
@@ -68,7 +68,7 @@ def train_loop(
         world_size=world_size,
         model=model,
         lr=0.1,
-        use_cuda=dist.get_backend() == dist.Backend.NCCL,
+        use_cuda=use_cuda,
         by_layer=by_layer,
     )
 

--- a/pytorch/linearmodels/epsilon-logistic-regression-all-reduce/requirements.txt
+++ b/pytorch/linearmodels/epsilon-logistic-regression-all-reduce/requirements.txt
@@ -1,2 +1,2 @@
 mlbench-core==2.3.2.dev1
-tensorpack
+tensorpack==0.9.8

--- a/pytorch/linearmodels/epsilon-logistic-regression-all-reduce/requirements.txt
+++ b/pytorch/linearmodels/epsilon-logistic-regression-all-reduce/requirements.txt
@@ -1,2 +1,2 @@
-mlbench-core==2.3.2.dev1
+mlbench-core==2.4.0
 tensorpack==0.9.8


### PR DESCRIPTION
Updates the base image and each image used for pytorch benchmarking.

Needs [#68](https://github.com/mlbench/mlbench-core/pull/68) to be merged before, as to update the version of mlbench_core

Closes #34 

I've tested that all images, backends (with and without GPU) work for all