### PR TITLE
Remove open/closed division from benchmarks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ mlbench Benchmarks: Distributed Machine Learning Benchmark
 
 A public and reproducible collection of reference implementations and benchmark suite for distributed machine learning algorithms, frameworks and systems.
 
-This repository contains the implementations for the various benchmark tasks for the closed division of mlbench.
+This repository contains the implementations for the various benchmark tasks in mlbench.
 
 
 * Project website: https://mlbench.github.io/

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -11,7 +11,7 @@ MLBench contains several benchmark tasks and implementations. Tasks combinations
 For an overview of MLBench tasks, please refer to the :doc:`Benchmarking Tasks Section <mlbench-docs:benchmark-tasks>`
 
 
-Closed Division Benchmark Implementations
+Benchmark Implementations
 -----------------------------------------
 
 A Benchmark Implementation is a model with fixed hyperparameters that solves a Benchmark Task.


### PR DESCRIPTION
This PR partially addresses https://github.com/mlbench/mlbench-benchmarks/issues/47